### PR TITLE
Remove erroneous "," from sensor config

### DIFF
--- a/melcloud-mqtt-bridge.py
+++ b/melcloud-mqtt-bridge.py
@@ -98,7 +98,7 @@ mqtt_sensor_config = """
  "unique_id": "%s-%s",
  "dev": {
      "ids": "%s",
-     "name": "MELCloud MQTT Bridge",
+     "name": "MELCloud MQTT Bridge"
  },
  "name": "%s",
  "state_topic": "melcloud/status/values",


### PR DESCRIPTION
Remove comma preventing Home Assistant discovery of all sensors.